### PR TITLE
Add a package header for installation by "M-x package-install-file"

### DIFF
--- a/org-manage.el
+++ b/org-manage.el
@@ -1,13 +1,14 @@
 ;;; org-manage.el --- Manage org files in a given directory
 
-;; Copyright (C) 2013 Yoshinari Nomura.
-;; Copyright (C) 2013 Daniel German
+;; Copyright (C) 2013-2016 Daniel German and contributors
 ;;
-;; version 0.2  <2013-05-29 Wed>
-;;
-;; Author:  Yoshinari Nomura <nom@quickhack.net>
-;; Author:  Daniel German    <dmg@uvic.ca>
-;;
+;; Author: Daniel German <dmg@uvic.ca> and contributors
+;; URL: http://github.com/dmgerman/org-manage/
+;; Package-Requires: ((org "8.0") (ctable "0.1.1"))
+;; Version: 0.2
+
+;;; Commentary:
+
 ;; Based on org-octopress.el by Yoshinari Nomura
 ;;
 ;; Licensed under the same terms as Org-mode (http://orgmode.org/).
@@ -16,7 +17,6 @@
 ;; (and its subdirectories).  It shows in a table each of the org
 ;; files, its title and last modification time. The user can easily
 ;; jump to any of those files from it.
-;;
 ;;
 ;; Requirements:
 ;;     You need to install ctable from https://github.com/kiwanami/emacs-ctable

--- a/readme.org
+++ b/readme.org
@@ -31,11 +31,15 @@ each file.
 
 ** How to use it
 
+Install the script =org-manage.el=. You can use =M-x
+package-install-file= if you use Emacs 24 or later, or you enabled
+=package.el=.
+
 Define the location where org files are to be found. Currently it only
 supports one directory. You can solve this by creating symbolic links
 from inside this directory to the locations of other org files. There
 are other configuration variables (e.g. how much to recurse, files to
-ignore, etc--see [[./org-manage.el][source code file of org-manage.el]].
+ignore, etc--see [[./org-manage.el][source code file of org-manage.el]]).
 
 #+BEGIN_SRC emacs_lisp
 (setq org-manage-directory-org       "~/myorgfiles")


### PR DESCRIPTION
Hi dmgerman,

These patches enables easy installation by package.el. You can install it by "M-x package-install-file", then specify location of downloaded org-manage.el file.

Please consider to merge the patches. Also, I think that this package should be registered at a package repository ex. MELPA.

Regards,
Shintaro
